### PR TITLE
[fix][scaleph-ui] jdbc source and jdbc sink select form can't find added datasource…

### DIFF
--- a/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-table-step/sink-table-step.component.html
+++ b/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-table-step/sink-table-step.component.html
@@ -30,7 +30,7 @@
             formControlName="dataSourceType"
             [dValidateRules]="formConfig.dataSourceTypeRules"
             [extraConfig]="{ selectedItemWithTemplate: { enable: true } }"
-            (valueChange)="listDataSource($event)"
+            (valueChange)="listDataSource($event, true)"
           >
             <ng-template let-option="option"> {{ option['label'] }} </ng-template>
           </d-select>

--- a/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-table-step/sink-table-step.component.ts
+++ b/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-table-step/sink-table-step.component.ts
@@ -74,6 +74,7 @@ export class SinkTableStepComponent implements OnInit {
       }
       if (stepAttrMap.get(STEP_ATTR_TYPE.dataSourceType)) {
         this.formGroup.patchValue({ dataSourceType: JSON.parse(stepAttrMap.get(STEP_ATTR_TYPE.dataSourceType)) });
+        this.listDataSource(this.formGroup.get(STEP_ATTR_TYPE.dataSourceType).value, false);
       }
       if (stepAttrMap.get(STEP_ATTR_TYPE.dataSource)) {
         this.formGroup.patchValue({ dataSource: JSON.parse(stepAttrMap.get(STEP_ATTR_TYPE.dataSource)) });
@@ -87,8 +88,10 @@ export class SinkTableStepComponent implements OnInit {
     });
   }
 
-  listDataSource(event: Dict) {
-    this.formGroup.get(STEP_ATTR_TYPE.dataSource).setValue(null);
+  listDataSource(event: Dict, reset: boolean) {
+    if (reset) {
+      this.formGroup.get(STEP_ATTR_TYPE.dataSource).setValue(null);
+    }
     this.dataSourceService.listByType(event?.value).subscribe((d) => {
       this.dataSourceList = d;
     });

--- a/scaleph-ui/src/app/pages/datadev/workbench/steps/source-table-step/source-table-step.component.html
+++ b/scaleph-ui/src/app/pages/datadev/workbench/steps/source-table-step/source-table-step.component.html
@@ -30,7 +30,7 @@
             formControlName="dataSourceType"
             [dValidateRules]="formConfig.dataSourceTypeRules"
             [extraConfig]="{ selectedItemWithTemplate: { enable: true } }"
-            (valueChange)="listDataSource($event)"
+            (valueChange)="listDataSource($event, true)"
           >
             <ng-template let-option="option"> {{ option['label'] }} </ng-template>
           </d-select>

--- a/scaleph-ui/src/app/pages/datadev/workbench/steps/source-table-step/source-table-step.component.ts
+++ b/scaleph-ui/src/app/pages/datadev/workbench/steps/source-table-step/source-table-step.component.ts
@@ -72,6 +72,7 @@ export class SourceTableStepComponent implements OnInit {
       }
       if (stepAttrMap.get(STEP_ATTR_TYPE.dataSourceType)) {
         this.formGroup.patchValue({ dataSourceType: JSON.parse(stepAttrMap.get(STEP_ATTR_TYPE.dataSourceType)) });
+        this.listDataSource(this.formGroup.get(STEP_ATTR_TYPE.dataSourceType).value, false);
       }
       if (stepAttrMap.get(STEP_ATTR_TYPE.dataSource)) {
         this.formGroup.patchValue({ dataSource: JSON.parse(stepAttrMap.get(STEP_ATTR_TYPE.dataSource)) });
@@ -80,8 +81,10 @@ export class SourceTableStepComponent implements OnInit {
     });
   }
 
-  listDataSource(event: Dict) {
-    this.formGroup.get(STEP_ATTR_TYPE.dataSource).setValue(null);
+  listDataSource(event: Dict, reset: boolean) {
+    if (reset) {
+      this.formGroup.get(STEP_ATTR_TYPE.dataSource).setValue(null);
+    }
     this.dataSourceService.listByType(event?.value).subscribe((d) => {
       this.dataSourceList = d;
     });


### PR DESCRIPTION

<!--

Thank you for contributing to Scaleph! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/flowerfine/scaleph/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

fix:https://github.com/flowerfine/scaleph/issues/53

## Brief change log
*(for example:)*
- *Add datasource plugin and jdbc datasource plugin implementations*
- *scaleph-ui datasource menu loads available datasource plugins automatically*
- *seatunnel connector-jdbc job retrieves datasource from datasource plugin*

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If necessary, please update the documentation to describe the new feature.
