### PR TITLE
[Feature][scaleph-ui] remove duplicated batch size parameter

### DIFF
--- a/scaleph-ui/src/app/@core/data/datadev.data.ts
+++ b/scaleph-ui/src/app/@core/data/datadev.data.ts
@@ -235,7 +235,6 @@ export const STEP_ATTR_TYPE = {
   formatConf: 'format_conf',
   schema: 'schema',
   table: 'table',
-  batch_size: 'batch_size',
   interval: 'interval',
   maxRetries: 'max_retries',
   dorisConf: 'doris_conf',

--- a/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-doris-step/sink-doris-step.component.ts
+++ b/scaleph-ui/src/app/pages/datadev/workbench/steps/sink-doris-step/sink-doris-step.component.ts
@@ -71,7 +71,7 @@ export class SinkDorisStepComponent implements OnInit {
         this.formGroup.patchValue({ dataSource: JSON.parse(stepAttrMap.get(STEP_ATTR_TYPE.dataSource)) });
       }
       this.formGroup.patchValue({ table: stepAttrMap.get(STEP_ATTR_TYPE.table) });
-      this.formGroup.patchValue({ batch_size: stepAttrMap.get(STEP_ATTR_TYPE.batch_size) });
+      this.formGroup.patchValue({ batch_size: stepAttrMap.get(STEP_ATTR_TYPE.batchSize) });
       this.formGroup.patchValue({ interval: stepAttrMap.get(STEP_ATTR_TYPE.interval) });
       this.formGroup.patchValue({ max_retries: stepAttrMap.get(STEP_ATTR_TYPE.maxRetries) });
       this.formGroup.patchValue({ doris_conf: stepAttrMap.get(STEP_ATTR_TYPE.dorisConf) });
@@ -84,7 +84,7 @@ export class SinkDorisStepComponent implements OnInit {
       stepAttrMap.set(STEP_ATTR_TYPE.stepTitle, this.formGroup.get(STEP_ATTR_TYPE.stepTitle).value);
       stepAttrMap.set(STEP_ATTR_TYPE.dataSource, this.formGroup.get(STEP_ATTR_TYPE.dataSource).value);
       stepAttrMap.set(STEP_ATTR_TYPE.table, this.formGroup.get(STEP_ATTR_TYPE.table).value);
-      stepAttrMap.set(STEP_ATTR_TYPE.batch_size, this.formGroup.get(STEP_ATTR_TYPE.batch_size).value);
+      stepAttrMap.set(STEP_ATTR_TYPE.batchSize, this.formGroup.get(STEP_ATTR_TYPE.batchSize).value);
       stepAttrMap.set(STEP_ATTR_TYPE.interval, this.formGroup.get(STEP_ATTR_TYPE.interval).value);
       stepAttrMap.set(STEP_ATTR_TYPE.maxRetries, this.formGroup.get(STEP_ATTR_TYPE.maxRetries).value);
       stepAttrMap.set(STEP_ATTR_TYPE.dorisConf, this.formGroup.get(STEP_ATTR_TYPE.dorisConf).value);


### PR DESCRIPTION
<!--

Thank you for contributing to Scaleph! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/flowerfine/scaleph/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
remove duplicated batch size parameter
see https://github.com/flowerfine/scaleph/pull/157

## Brief change log
*(for example:)*
- *Add datasource plugin and jdbc datasource plugin implementations*
- *scaleph-ui datasource menu loads available datasource plugins automatically*
- *seatunnel connector-jdbc job retrieves datasource from datasource plugin*

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If necessary, please update the documentation to describe the new feature.
