### PR TITLE
[Bugfix] Fix bug that could not get flink job status in frontend.

### DIFF
--- a/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/WsFlinkService.java
+++ b/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/WsFlinkService.java
@@ -38,4 +38,6 @@ public interface WsFlinkService {
 
     void triggerSavepoint(Long id) throws Exception;
 
+    WsFlinkJobDTO query(WsFlinkJobDTO wsFlinkJobDTO);
+
 }

--- a/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/WsFlinkService.java
+++ b/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/WsFlinkService.java
@@ -38,6 +38,6 @@ public interface WsFlinkService {
 
     void triggerSavepoint(Long id) throws Exception;
 
-    WsFlinkJobDTO query(WsFlinkJobDTO wsFlinkJobDTO);
+    void updateJobInstanceState(WsFlinkJobDTO wsFlinkJobDTO);
 
 }

--- a/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkJobServiceImpl.java
+++ b/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkJobServiceImpl.java
@@ -25,12 +25,15 @@ import cn.sliew.scaleph.dao.entity.master.ws.WsFlinkJob;
 import cn.sliew.scaleph.dao.entity.master.ws.WsFlinkJobInstance;
 import cn.sliew.scaleph.dao.mapper.master.ws.WsFlinkJobMapper;
 import cn.sliew.scaleph.engine.flink.service.WsFlinkJobService;
+import cn.sliew.scaleph.engine.flink.service.WsFlinkService;
 import cn.sliew.scaleph.engine.flink.service.convert.WsFlinkJobConvert;
 import cn.sliew.scaleph.engine.flink.service.dto.WsFlinkJobDTO;
 import cn.sliew.scaleph.engine.flink.service.param.WsFlinkJobListParam;
 import cn.sliew.scaleph.system.snowflake.UidGenerator;
 import cn.sliew.scaleph.system.snowflake.exception.UidGenerateException;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,10 +43,14 @@ import java.util.List;
 @Service
 public class WsFlinkJobServiceImpl implements WsFlinkJobService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(WsFlinkJobServiceImpl.class);
+
     @Autowired
     private UidGenerator defaultUidGenerator;
     @Autowired
     private WsFlinkJobMapper flinkJobMapper;
+    @Autowired
+    private WsFlinkService flinkService;
 
     @Override
     public Page<WsFlinkJobDTO> list(WsFlinkJobListParam param) {
@@ -63,7 +70,9 @@ public class WsFlinkJobServiceImpl implements WsFlinkJobService {
     @Override
     public WsFlinkJobDTO selectOne(Long id) {
         final WsFlinkJob record = flinkJobMapper.selectOne(id);
-        return WsFlinkJobConvert.INSTANCE.toDto(record);
+        WsFlinkJobDTO dto = WsFlinkJobConvert.INSTANCE.toDto(record);
+        dto = flinkService.query(dto);
+        return dto;
     }
 
     @Transactional(rollbackFor = Exception.class, transactionManager = DataSourceConstants.MASTER_TRANSACTION_MANAGER_FACTORY)

--- a/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkJobServiceImpl.java
+++ b/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkJobServiceImpl.java
@@ -32,8 +32,6 @@ import cn.sliew.scaleph.engine.flink.service.param.WsFlinkJobListParam;
 import cn.sliew.scaleph.system.snowflake.UidGenerator;
 import cn.sliew.scaleph.system.snowflake.exception.UidGenerateException;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,8 +40,6 @@ import java.util.List;
 
 @Service
 public class WsFlinkJobServiceImpl implements WsFlinkJobService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(WsFlinkJobServiceImpl.class);
 
     @Autowired
     private UidGenerator defaultUidGenerator;
@@ -70,9 +66,9 @@ public class WsFlinkJobServiceImpl implements WsFlinkJobService {
     @Override
     public WsFlinkJobDTO selectOne(Long id) {
         final WsFlinkJob record = flinkJobMapper.selectOne(id);
-        WsFlinkJobDTO dto = WsFlinkJobConvert.INSTANCE.toDto(record);
-        dto = flinkService.query(dto);
-        return dto;
+        WsFlinkJobDTO wsFlinkJobDTO = WsFlinkJobConvert.INSTANCE.toDto(record);
+        flinkService.updateJobInstanceState(wsFlinkJobDTO);
+        return wsFlinkJobDTO;
     }
 
     @Transactional(rollbackFor = Exception.class, transactionManager = DataSourceConstants.MASTER_TRANSACTION_MANAGER_FACTORY)

--- a/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkServiceImpl.java
+++ b/scaleph-engine/scaleph-engine-flink/src/main/java/cn/sliew/scaleph/engine/flink/service/impl/WsFlinkServiceImpl.java
@@ -18,8 +18,6 @@
 
 package cn.sliew.scaleph.engine.flink.service.impl;
 
-import cn.hutool.json.JSONObject;
-import cn.hutool.json.JSONUtil;
 import cn.sliew.flinkful.cli.base.CliClient;
 import cn.sliew.flinkful.cli.base.SessionClient;
 import cn.sliew.flinkful.cli.base.submit.PackageJarJob;
@@ -66,12 +64,11 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.rest.handler.async.TriggerResponse;
 import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.stop.StopWithSavepointRequestBody;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.hc.client5.http.fluent.Request;
-import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -429,12 +426,8 @@ public class WsFlinkServiceImpl implements WsFlinkService {
     }
 
     @Override
-    public WsFlinkJobDTO query(WsFlinkJobDTO wsFlinkJobDTO) {
-        // TODO: This may fail if HA is enabled. So it's better to query using Flink Client...
-        // TODO: If use Flink client, May be modify flinkful-client and rebuild Flink Client Instance. And different
-        // TODO: Flink client version may causes some problems also...
-        // TODO: We need to discuss
-        WsFlinkJobInstanceDTO flinkJobInstance = wsFlinkJobDTO.getWsFlinkJobInstance();
+    public void updateJobInstanceState(WsFlinkJobDTO wsFlinkJobDTO) {
+        final WsFlinkJobInstanceDTO flinkJobInstance = wsFlinkJobDTO.getWsFlinkJobInstance();
         FlinkJobState currentJobState = flinkJobInstance.getJobState();
         if (Objects.isNull(currentJobState) ||
                 currentJobState == FlinkJobState.INITIALIZING ||
@@ -445,29 +438,17 @@ public class WsFlinkServiceImpl implements WsFlinkService {
                 currentJobState == FlinkJobState.CANCELLING) {
             String webInterfaceUrl = flinkJobInstance.getWebInterfaceUrl();
             if (webInterfaceUrl != null) {
-                while (webInterfaceUrl.endsWith("/")) {
-                    webInterfaceUrl = webInterfaceUrl.substring(0, webInterfaceUrl.length() - 1);
-                }
-                String flinkJobQueryUrl = String.format("%s/jobs/%s", webInterfaceUrl, flinkJobInstance.getJobId());
                 try {
-                    String flinkJobQueryResponseJson = Request.get(flinkJobQueryUrl)
-                            .connectTimeout(Timeout.ofSeconds(3))
-                            .execute()
-                            .returnContent()
-                            .asString();
-                    JSONObject jsonObject = JSONUtil.parseObj(flinkJobQueryResponseJson);
-                    if (!jsonObject.containsKey("errors")) {
-                        Long startTime = jsonObject.getLong("start-time", null);
-                        flinkJobInstance.setStartTime(new Date(startTime));
-                        Long endTime = jsonObject.getLong("end-time", null);
-                        flinkJobInstance.setEndTime(new Date(endTime));
-                        // Set default state to Failed
-                        FlinkJobState jobState = FlinkJobState.valueOf(
-                                jsonObject.getStr("state", "FAILED").toUpperCase());
-                        flinkJobInstance.setJobState(jobState);
-                        Long duration = jsonObject.getLong("duration", null);
-                        flinkJobInstance.setDuration(duration);
-                    }
+                    URL url = new URL(webInterfaceUrl);
+                    String address = url.getHost();
+                    int port = url.getPort();
+                    RestClient restClient = new FlinkRestClient(address, port, new Configuration());
+                    JobClient jobClient = restClient.job();
+                    JobDetailsInfo jobDetailsInfo = jobClient.jobDetail(flinkJobInstance.getJobId()).get();
+                    flinkJobInstance.setStartTime(new Date(jobDetailsInfo.getStartTime()));
+                    flinkJobInstance.setEndTime(new Date(jobDetailsInfo.getEndTime()));
+                    flinkJobInstance.setJobState(FlinkJobState.valueOf(jobDetailsInfo.getJobStatus().name()));
+                    flinkJobInstance.setDuration(jobDetailsInfo.getDuration());
                 } catch (Exception e) {
                     throw new IllegalArgumentException(e);
                 }
@@ -478,7 +459,6 @@ public class WsFlinkServiceImpl implements WsFlinkService {
                 }
             }
         }
-        return wsFlinkJobDTO;
     }
 
     private ClusterClient createYarnSessionCluster(WsFlinkClusterConfigDTO wsFlinkClusterConfigDTO) throws Exception {


### PR DESCRIPTION
## Purpose of this pull request
This pr fixed a bug:
Could not get flink job instance status in frontend.

## Brief change log
* Add `query` method to `WsFlinkService`. This method will query flink webui and get flink job state
* After query flink job instance information, Update the job instance data to the database.

## Other
I fix this bug using Flinkful api. But there may be some problems in these situations:
* Flink HA changes in standalone cluster mode.
* Flink application restart on yarn cluster.
These will cause flink application web interface ui URL changes. So this solution will NOT work

The best way to solve this problem is to use Flink Client to query job information.
