### PR TITLE
[Feature][scaleph-ui-react] support automatic refresh on flink kubernetes session-cluster detail web

### DIFF
--- a/scaleph-api/src/main/java/cn/sliew/scaleph/api/controller/ws/WsFlinkKubernetesSessionClusterController.java
+++ b/scaleph-api/src/main/java/cn/sliew/scaleph/api/controller/ws/WsFlinkKubernetesSessionClusterController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @Tag(name = "Flink Kubernetes管理-Flink SessionCluster管理")
 @RestController
@@ -166,7 +167,7 @@ public class WsFlinkKubernetesSessionClusterController {
     @GetMapping("{id}/status")
     @Operation(summary = "获取 SessionCluster 状态", description = "获取 SessionCluster 状态")
     public ResponseEntity<ResponseVO<GenericKubernetesResource>> getSessionClusterStatus(@PathVariable("id") Long id) throws Exception {
-        GenericKubernetesResource sessionCluster = wsFlinkKubernetesSessionClusterService.getStatusWithoutManagedFields(id);
-        return new ResponseEntity<>(ResponseVO.success(sessionCluster), HttpStatus.OK);
+        Optional<GenericKubernetesResource> sessionCluster = wsFlinkKubernetesSessionClusterService.getStatusWithoutManagedFields(id);
+        return new ResponseEntity<>(ResponseVO.success(sessionCluster.orElse(null)), HttpStatus.OK);
     }
 }

--- a/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/action/FlinkSessionClusterStatusSyncJob.java
+++ b/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/action/FlinkSessionClusterStatusSyncJob.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -56,9 +57,9 @@ public class FlinkSessionClusterStatusSyncJob extends AbstractWorkFlow {
 
     private void doProcess(Long sessionClusterId) {
         try {
-            GenericKubernetesResource genericKubernetesResource = wsFlinkKubernetesSessionClusterService.getStatus(sessionClusterId);
-            if (genericKubernetesResource != null) {
-                String json = JacksonUtil.toJsonString(genericKubernetesResource.get("status"));
+            Optional<GenericKubernetesResource> optional = wsFlinkKubernetesSessionClusterService.getStatus(sessionClusterId);
+            if (optional.isPresent()) {
+                String json = JacksonUtil.toJsonString(optional.get().get("status"));
                 FlinkDeploymentStatus status = JacksonUtil.parseJsonString(json, FlinkDeploymentStatus.class);
                 wsFlinkKubernetesSessionClusterService.updateStatus(sessionClusterId, status);
             } else {

--- a/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/FlinkKubernetesOperatorService.java
+++ b/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/FlinkKubernetesOperatorService.java
@@ -22,9 +22,11 @@ import cn.sliew.scaleph.engine.flink.kubernetes.resource.sessioncluster.FlinkSes
 import cn.sliew.scaleph.engine.flink.kubernetes.service.dto.WsFlinkKubernetesSessionClusterDTO;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 
+import java.util.Optional;
+
 public interface FlinkKubernetesOperatorService {
 
-    GenericKubernetesResource getSessionCluster(WsFlinkKubernetesSessionClusterDTO sessionClusterDTO) throws Exception;
+    Optional<GenericKubernetesResource> getSessionCluster(WsFlinkKubernetesSessionClusterDTO sessionClusterDTO) throws Exception;
 
     void deploySessionCluster(Long clusterCredentialId, FlinkSessionCluster sessionCluster) throws Exception;
 

--- a/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/WsFlinkKubernetesSessionClusterService.java
+++ b/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/WsFlinkKubernetesSessionClusterService.java
@@ -65,7 +65,7 @@ public interface WsFlinkKubernetesSessionClusterService {
 
     void shutdown(Long id) throws Exception;
 
-    GenericKubernetesResource getStatus(Long id);
+    Optional<GenericKubernetesResource> getStatus(Long id);
 
-    GenericKubernetesResource getStatusWithoutManagedFields(Long id);
+    Optional<GenericKubernetesResource> getStatusWithoutManagedFields(Long id);
 }

--- a/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/impl/FlinkKubernetesOperatorServiceImpl.java
+++ b/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/impl/FlinkKubernetesOperatorServiceImpl.java
@@ -31,6 +31,8 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class FlinkKubernetesOperatorServiceImpl implements FlinkKubernetesOperatorService {
 
@@ -38,12 +40,13 @@ public class FlinkKubernetesOperatorServiceImpl implements FlinkKubernetesOperat
     private KuberenetesService kuberenetesService;
 
     @Override
-    public GenericKubernetesResource getSessionCluster(WsFlinkKubernetesSessionClusterDTO sessionClusterDTO) throws Exception {
+    public Optional<GenericKubernetesResource> getSessionCluster(WsFlinkKubernetesSessionClusterDTO sessionClusterDTO) throws Exception {
         KubernetesClient client = kuberenetesService.getClient(sessionClusterDTO.getClusterCredentialId());
-        return client.genericKubernetesResources(Constant.API_VERSION, Constant.FLINK_DEPLOYMENT)
+        GenericKubernetesResource resource = client.genericKubernetesResources(Constant.API_VERSION, Constant.FLINK_DEPLOYMENT)
                 .inNamespace(sessionClusterDTO.getNamespace())
                 .withName(sessionClusterDTO.getSessionClusterId())
                 .get();
+        return Optional.ofNullable(resource);
     }
 
     @Override

--- a/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/impl/WsFlinkKubernetesSessionClusterServiceImpl.java
+++ b/scaleph-engine/scaleph-engine-flink-kubernetes/src/main/java/cn/sliew/scaleph/engine/flink/kubernetes/service/impl/WsFlinkKubernetesSessionClusterServiceImpl.java
@@ -225,7 +225,7 @@ public class WsFlinkKubernetesSessionClusterServiceImpl implements WsFlinkKubern
     }
 
     @Override
-    public GenericKubernetesResource getStatus(Long id) {
+    public Optional<GenericKubernetesResource> getStatus(Long id) {
         try {
             WsFlinkKubernetesSessionClusterDTO sessionClusterDTO = selectOne(id);
             return flinkKubernetesOperatorService.getSessionCluster(sessionClusterDTO);
@@ -236,13 +236,17 @@ public class WsFlinkKubernetesSessionClusterServiceImpl implements WsFlinkKubern
     }
 
     @Override
-    public GenericKubernetesResource getStatusWithoutManagedFields(Long id) {
-        GenericKubernetesResource status = getStatus(id);
+    public Optional<GenericKubernetesResource> getStatusWithoutManagedFields(Long id) {
+        Optional<GenericKubernetesResource> optional = getStatus(id);
+        if (optional.isEmpty()) {
+            return Optional.empty();
+        }
+        GenericKubernetesResource status = optional.get();
         GenericKubernetesResourceBuilder builder = new GenericKubernetesResourceBuilder(status);
         ObjectMetaBuilder objectMetaBuilder = new ObjectMetaBuilder(status.getMetadata());
         objectMetaBuilder.removeMatchingFromManagedFields(Predicates.isTrue());
         builder.withMetadata(objectMetaBuilder.build());
-        return builder.build();
+        return Optional.of(builder.build());
     }
 
 }

--- a/scaleph-ui-react/src/locales/zh-CN/pages/base.ts
+++ b/scaleph-ui-react/src/locales/zh-CN/pages/base.ts
@@ -39,6 +39,7 @@ export default {
   'app.common.operate.reset.label': '重置',
   'app.common.operate.confirm.label': '确定',
   'app.common.operate.submit.label': '提交',
+  'app.common.operate.submit.success': '提交成功',
   'app.common.operate.submit.confirm.title': '确定提交？',
   'app.common.operate.submit.confirm.content': '提交前请仔细检查，谨慎操作',
   'app.common.operate.cancel.label': '取消',

--- a/scaleph-ui-react/src/models/sessionClusterDetail.ts
+++ b/scaleph-ui-react/src/models/sessionClusterDetail.ts
@@ -1,0 +1,45 @@
+import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
+import {Effect, Reducer} from "umi";
+import {WsFlinkKubernetesSessionClusterService} from "@/services/project/WsFlinkKubernetesSessionClusterService";
+
+export interface StateType {
+  sessionCluster: WsFlinkKubernetesSessionCluster,
+}
+
+export interface ModelType {
+  namespace: string;
+
+  state: StateType;
+
+  effects: {
+    queryTemplate: Effect;
+  };
+
+  reducers: {
+    updateTemplate: Reducer<StateType>;
+  };
+}
+
+const model: ModelType = {
+  state: {
+    sessionCluster: null,
+  },
+
+  effects: {
+    *querySessionCluster({payload}, {call, put}) {
+      const {data} = yield call(WsFlinkKubernetesSessionClusterService.selectOne, payload);
+      yield put({type: 'updateSessionCluster', payload: {sessionCluster: data}});
+    },
+  },
+
+  reducers: {
+    updateSessionCluster(state, {payload}) {
+      return {
+        ...state,
+        sessionCluster: payload.sessionCluster
+      };
+    },
+  },
+};
+
+export default model;

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Deployment/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Deployment/index.tsx
@@ -1,13 +1,12 @@
 import {history, useAccess, useIntl} from "umi";
 import React, {useRef, useState} from "react";
-import {Button, message, Modal, Space, Tag, Tooltip} from "antd";
+import {Button, message, Modal, Space, Tooltip} from "antd";
 import {DeleteOutlined, EditOutlined, NodeIndexOutlined} from "@ant-design/icons";
-import {ActionType, ProColumns, ProFormInstance, ProFormSelect, ProTable} from "@ant-design/pro-components";
-import {DICT_TYPE, PRIVILEGE_CODE, WORKSPACE_CONF} from "@/constant";
+import {ActionType, ProColumns, ProFormInstance, ProTable} from "@ant-design/pro-components";
+import {PRIVILEGE_CODE, WORKSPACE_CONF} from "@/constant";
 import {WsFlinkKubernetesDeployment} from "@/services/project/typings";
 import {WsFlinkKubernetesDeploymentService} from "@/services/project/WsFlinkKubernetesDeploymentService";
 import DeploymentForm from "@/pages/Project/Workspace/Kubernetes/Deployment/DeploymentForm";
-import {DictDataService} from "@/services/admin/dictData.service";
 
 const FlinkKubernetesDeploymentWeb: React.FC = () => {
   const intl = useIntl();
@@ -89,6 +88,7 @@ const FlinkKubernetesDeploymentWeb: React.FC = () => {
               <Button
                 shape="default"
                 type="link"
+                danger
                 icon={<DeleteOutlined/>}
                 onClick={() => {
                   Modal.confirm({

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Job/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Job/index.tsx
@@ -138,6 +138,7 @@ const FlinkKubernetesJobWeb: React.FC = () => {
               <Button
                 shape="default"
                 type="link"
+                danger
                 icon={<DeleteOutlined/>}
                 onClick={() => {
                   Modal.confirm({

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Configuration/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Configuration/index.tsx
@@ -1,7 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {Props} from '@/app.d';
-import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
-import {useAccess, useIntl} from "umi";
+import {connect, useAccess, useIntl} from "umi";
 import {ProColumns, ProTable} from "@ant-design/pro-components";
 
 type Config = {
@@ -9,21 +7,23 @@ type Config = {
   value?: any;
 };
 
-const FlinkKubernetesSessinClusterDetailFlinkConfigurationWeb: React.FC<Props<WsFlinkKubernetesSessionCluster>> = ({data}) => {
+const FlinkKubernetesSessinClusterDetailFlinkConfigurationWeb: React.FC = (props: any) => {
   const intl = useIntl();
   const access = useAccess();
   const [dataSource, setDataSource] = useState<Config[]>([])
 
   useEffect(() => {
-    const config: Array<Config> = []
-    Object.entries<[string, any][]>(data.flinkConfiguration ? {...data.flinkConfiguration} : {}).forEach(([key, value]) => {
-      config.push({
-        key: key,
-        value: value
-      })
-    });
-    setDataSource(config)
-  }, []);
+    if (props.sessionClusterDetail.sessionCluster) {
+      const config: Array<Config> = []
+      Object.entries<[string, any][]>(props.sessionClusterDetail.sessionCluster.flinkConfiguration ? {...props.sessionClusterDetail.sessionCluster.flinkConfiguration} : {}).forEach(([key, value]) => {
+        config.push({
+          key: key,
+          value: value
+        })
+      });
+      setDataSource(config)
+    }
+  }, [props.sessionClusterDetail.sessionCluster]);
 
   const tableColumns: ProColumns<Config>[] = [
     {
@@ -48,4 +48,5 @@ const FlinkKubernetesSessinClusterDetailFlinkConfigurationWeb: React.FC<Props<Ws
   );
 }
 
-export default FlinkKubernetesSessinClusterDetailFlinkConfigurationWeb;
+const mapModelToProps = ({sessionClusterDetail}: any) => ({sessionClusterDetail})
+export default connect(mapModelToProps)(FlinkKubernetesSessinClusterDetailFlinkConfigurationWeb);

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Log/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Log/index.tsx
@@ -1,15 +1,20 @@
-import React from "react";
-import {Props} from '@/app.d';
-import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
-import {useAccess, useIntl} from "umi";
+import React, {useEffect} from "react";
+import {connect, useAccess, useIntl} from "umi";
 
-const FlinkKubernetesSessinClusterDetailLogWeb: React.FC<Props<WsFlinkKubernetesSessionCluster>> = ({data}) => {
+const FlinkKubernetesSessinClusterDetailLogWeb: React.FC = (props: any) => {
   const intl = useIntl();
   const access = useAccess();
+
+  useEffect(() => {
+    if (props.sessionClusterDetail.sessionCluster) {
+
+    }
+  }, [props.sessionClusterDetail.sessionCluster]);
 
   return (
     <div>FlinkKubernetesSessinClusterDetailLogWeb</div>
   );
 }
 
-export default FlinkKubernetesSessinClusterDetailLogWeb;
+const mapModelToProps = ({sessionClusterDetail}: any) => ({sessionClusterDetail})
+export default connect(mapModelToProps)(FlinkKubernetesSessinClusterDetailLogWeb);

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Options/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/Options/index.tsx
@@ -1,8 +1,6 @@
-import React from "react";
-import {Props} from '@/app.d';
-import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
-import {useAccess, useIntl} from "umi";
-import {ProForm} from "@ant-design/pro-components";
+import {connect} from "umi";
+import React, {useEffect, useRef} from "react";
+import {ProForm, ProFormInstance} from "@ant-design/pro-components";
 import AdvancedBasic from "@/pages/Project/Workspace/Kubernetes/Template/Detail/Advanced/AdvancedBasic";
 import AdvancedResource from "@/pages/Project/Workspace/Kubernetes/Template/Detail/Advanced/AdvancedResource";
 import AdvancedCheckpoint from "@/pages/Project/Workspace/Kubernetes/Template/Detail/Advanced/AdvancedCheckpoint";
@@ -16,16 +14,21 @@ import AdvancedHighAvailability
 import AdvancedAdditional from "@/pages/Project/Workspace/Kubernetes/Template/Detail/Advanced/AdvancedAdditional";
 import {WsFlinkKubernetesTemplateService} from "@/services/project/WsFlinkKubernetesTemplateService";
 
-const FlinkKubernetesSessinClusterDetailOptionsWeb: React.FC<Props<WsFlinkKubernetesSessionCluster>> = ({data}) => {
-  const intl = useIntl();
-  const access = useAccess();
+const FlinkKubernetesSessinClusterDetailOptionsWeb: React.FC = (props: any) => {
+  const formRef = useRef<ProFormInstance>();
+
+  useEffect(() => {
+    if (props.sessionClusterDetail.sessionCluster) {
+      formRef.current?.setFieldsValue(WsFlinkKubernetesTemplateService.parseData({...props.sessionClusterDetail.sessionCluster}))
+    }
+  }, [props.sessionClusterDetail.sessionCluster]);
 
   return (
     <ProForm
+      formRef={formRef}
       grid={true}
       disabled
       submitter={false}
-      initialValues={WsFlinkKubernetesTemplateService.parseData({...data})}
     >
       <AdvancedBasic/>
       <AdvancedResource/>
@@ -39,4 +42,5 @@ const FlinkKubernetesSessinClusterDetailOptionsWeb: React.FC<Props<WsFlinkKubern
   );
 }
 
-export default FlinkKubernetesSessinClusterDetailOptionsWeb;
+const mapModelToProps = ({sessionClusterDetail}: any) => ({sessionClusterDetail})
+export default connect(mapModelToProps)(FlinkKubernetesSessinClusterDetailOptionsWeb);

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/PodTemplate/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/PodTemplate/index.tsx
@@ -1,15 +1,20 @@
-import React from "react";
-import {Props} from '@/app.d';
-import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
-import {useAccess, useIntl} from "umi";
+import React, {useEffect} from "react";
+import {connect, useAccess, useIntl} from "umi";
 
-const FlinkKubernetesSessinClusterDetailPodTemplateWeb: React.FC<Props<WsFlinkKubernetesSessionCluster>> = ({data}) => {
+const FlinkKubernetesSessinClusterDetailPodTemplateWeb: React.FC = (props: any) => {
   const intl = useIntl();
   const access = useAccess();
+
+  useEffect(() => {
+    if (props.sessionClusterDetail.sessionCluster) {
+
+    }
+  }, [props.sessionClusterDetail.sessionCluster]);
 
   return (
     <div>FlinkKubernetesSessinClusterDetailPodTemplateWeb</div>
   );
 }
 
-export default FlinkKubernetesSessinClusterDetailPodTemplateWeb;
+const mapModelToProps = ({sessionClusterDetail}: any) => ({sessionClusterDetail})
+export default connect(mapModelToProps)(FlinkKubernetesSessinClusterDetailPodTemplateWeb);

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/YAML/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/Detail/YAML/index.tsx
@@ -1,15 +1,13 @@
 import React, {useEffect, useRef, useState} from "react";
 import Editor, {Monaco, useMonaco} from "@monaco-editor/react";
 import YAML from "yaml";
-import {Props} from '@/app.d';
 import {WsFlinkKubernetesSessionCluster} from "@/services/project/typings";
 import {WsFlinkKubernetesSessionClusterService} from "@/services/project/WsFlinkKubernetesSessionClusterService";
+import {connect} from "umi";
 
-const FlinkKubernetesSessinClusterDetailYAMLWeb: React.FC<Props<WsFlinkKubernetesSessionCluster>> = ({data}) => {
-
+const FlinkKubernetesSessinClusterDetailYAMLWeb: React.FC = (props: any) => {
   const editorRef = useRef(null);
   const monaco = useMonaco();
-
   const [sessionCluster, setSessionCluster] = useState<string>()
 
   useEffect(() => {
@@ -18,16 +16,24 @@ const FlinkKubernetesSessinClusterDetailYAMLWeb: React.FC<Props<WsFlinkKubernete
   }, [monaco]);
 
   useEffect(() => {
-    if (data.state) {
-      WsFlinkKubernetesSessionClusterService.status(data).then((response) => {
+    if (props.sessionClusterDetail.sessionCluster) {
+      const sessionCluster: WsFlinkKubernetesSessionCluster = {...props.sessionClusterDetail.sessionCluster}
+      sessionCluster.supportSqlGateway = null
+      refreshYaml(sessionCluster)
+    }
+  }, [props.sessionClusterDetail.sessionCluster]);
+
+  const refreshYaml = (sessionCluster: WsFlinkKubernetesSessionCluster) => {
+    if (sessionCluster.state) {
+      WsFlinkKubernetesSessionClusterService.status(sessionCluster).then((response) => {
         setSessionCluster(YAML.stringify(response.data))
       })
     } else {
-      WsFlinkKubernetesSessionClusterService.asYAML(data).then((response) => {
+      WsFlinkKubernetesSessionClusterService.asYAML(sessionCluster).then((response) => {
         setSessionCluster(YAML.stringify(response.data))
       })
     }
-  }, []);
+  }
 
   const handleEditorDidMount = (editor, monaco: Monaco) => {
     editorRef.current = editor;
@@ -52,4 +58,5 @@ const FlinkKubernetesSessinClusterDetailYAMLWeb: React.FC<Props<WsFlinkKubernete
   );
 }
 
-export default FlinkKubernetesSessinClusterDetailYAMLWeb;
+const mapModelToProps = ({sessionClusterDetail}: any) => ({sessionClusterDetail})
+export default connect(mapModelToProps)(FlinkKubernetesSessinClusterDetailYAMLWeb);

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/index.tsx
@@ -1,6 +1,6 @@
 import {history, useAccess, useIntl} from "umi";
 import React, {useRef, useState} from "react";
-import {Button, message, Modal, Space, Tooltip} from "antd";
+import {Button, message, Modal, Popconfirm, Space, Tooltip} from "antd";
 import {CaretRightOutlined, CloseOutlined, DeleteOutlined, EyeOutlined} from "@ant-design/icons";
 import {ActionType, ProColumns, ProFormInstance, ProFormSwitch, ProTable} from "@ant-design/pro-components";
 import {DICT_TYPE, PRIVILEGE_CODE, WORKSPACE_CONF} from "@/constant";
@@ -109,26 +109,46 @@ const FlinkKubernetesSessionClusterWeb: React.FC = () => {
             </Button>
           )}
           {access.canAccess(PRIVILEGE_CODE.datadevJobEdit) && (
-            <Button
-              shape="default"
-              type="link"
-              icon={<CaretRightOutlined/>}
+            <Popconfirm
+              title={intl.formatMessage({id: 'app.common.operate.submit.confirm.title'})}
               disabled={record.state}
-              onClick={() => WsFlinkKubernetesSessionClusterService.deploy(record)}
+              onConfirm={() => {
+                WsFlinkKubernetesSessionClusterService.deploy(record).then(response => {
+                  message.success(intl.formatMessage({id: 'app.common.operate.submit.success'}));
+                  actionRef.current?.reload()
+                })
+              }}
             >
-              {intl.formatMessage({id: 'app.common.operate.start.label'})}
-            </Button>
+              <Button
+                shape="default"
+                type="link"
+                disabled={record.state}
+                icon={<CaretRightOutlined/>}
+              >
+                {intl.formatMessage({id: 'app.common.operate.start.label'})}
+              </Button>
+            </Popconfirm>
           )}
           {access.canAccess(PRIVILEGE_CODE.datadevJobEdit) && (
-            <Button
-              shape="default"
-              type="link"
-              icon={<CloseOutlined/>}
+            <Popconfirm
+              title={intl.formatMessage({id: 'app.common.operate.submit.confirm.title'})}
               disabled={!record.state}
-              onClick={() => WsFlinkKubernetesSessionClusterService.shutdown(record)}
+              onConfirm={() => {
+                WsFlinkKubernetesSessionClusterService.shutdown(record).then(response => {
+                  message.success(intl.formatMessage({id: 'app.common.operate.submit.success'}));
+                  actionRef.current?.reload()
+                })
+              }}
             >
-              {intl.formatMessage({id: 'app.common.operate.stop.label'})}
-            </Button>
+              <Button
+                shape="default"
+                type="link"
+                icon={<CloseOutlined/>}
+                disabled={!record.state}
+              >
+                {intl.formatMessage({id: 'app.common.operate.stop.label'})}
+              </Button>
+            </Popconfirm>
           )}
           {access.canAccess(PRIVILEGE_CODE.datadevDatasourceDelete) && (
             <Button

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/SessionCluster/index.tsx
@@ -154,6 +154,7 @@ const FlinkKubernetesSessionClusterWeb: React.FC = () => {
             <Button
               shape="default"
               type="link"
+              danger
               icon={<DeleteOutlined/>}
               disabled={record.state}
               onClick={() => {

--- a/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Template/index.tsx
+++ b/scaleph-ui-react/src/pages/Project/Workspace/Kubernetes/Template/index.tsx
@@ -90,6 +90,7 @@ const FlinkKubernetesDeploymentTemplateWeb: React.FC = () => {
               <Button
                 shape="default"
                 type="link"
+                danger
                 icon={<DeleteOutlined/>}
                 onClick={() => {
                   Modal.confirm({


### PR DESCRIPTION
<!--

Thank you for contributing to Scaleph! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/flowerfine/scaleph/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
support automatic refresh on flink kubernetes session-cluster detail web
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Brief change log
- support automatic refresh on flink kubernetes session-cluster detail web

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If necessary, please update the documentation to describe the new feature.
