### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/tools/docker/deploy/kafka/backup.yml
+++ b/tools/docker/deploy/kafka/backup.yml
@@ -16,7 +16,7 @@
 
 services:
   zookeeper:
-    image: bitnami/zookeeper:3.9.2
+    image: soldevelo/zookeeper:3.9.5
     container_name: zookeeper
     ports:
       - 2181:2181
@@ -28,7 +28,7 @@ services:
       - scaleph
 
   kafka:
-    image: bitnami/kafka:3.7
+    image: soldevelo/kafka:3.7
     container_name: kafka
     depends_on:
       - zookeeper

--- a/tools/docker/deploy/kafka/docker-compose.yml
+++ b/tools/docker/deploy/kafka/docker-compose.yml
@@ -16,7 +16,7 @@
 
 services:
   zookeeper:
-    image: bitnami/zookeeper:3.9.2
+    image: soldevelo/zookeeper:3.9.5
     container_name: zookeeper
     ports:
       - 2181:2181
@@ -28,7 +28,7 @@ services:
       - scaleph
 
   kafka:
-    image: bitnami/kafka:3.7
+    image: soldevelo/kafka:3.7
     container_name: kafka
     depends_on:
       - zookeeper

--- a/tools/docker/deploy/scaleph/docker-compose.yml
+++ b/tools/docker/deploy/scaleph/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - scaleph
 
   redis:
-    image: bitnami/redis:7.0.10
+    image: soldevelo/redis:7.0.15
     container_name: redis
     environment:
       - REDIS_PORT_NUMBER=6379

--- a/tools/docker/local/docker-compose.yml
+++ b/tools/docker/local/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - scaleph
 
   redis:
-    image: bitnami/redis:7.0.10
+    image: soldevelo/redis:7.0.15
     container_name: redis
     environment:
       - REDIS_PORT_NUMBER=6379


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/redis:7.0.10` → [`soldevelo/redis:7.0.15`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/zookeeper:3.9.2` → [`soldevelo/zookeeper:3.9.5`](https://hub.docker.com/r/soldevelo/zookeeper)
- `bitnami/kafka:3.7` → [`soldevelo/kafka:3.7`](https://hub.docker.com/r/soldevelo/kafka)